### PR TITLE
fix descargas

### DIFF
--- a/python/main-classic/channels/descargas.py
+++ b/python/main-classic/channels/descargas.py
@@ -258,12 +258,12 @@ def move_to_libray(item):
       logger.error("No se ha encontrado el archivo: %s" % origen)
     
     if filetools.isfile(destino):
-      if item.contentType == "movie":
+      if item.contentType == "movie" and item.infoLabels["tmdb_id"]:
         library_item = Item(title="Descargado: %s" % item.downloadFilename, channel= "descargas", action="findvideos", infoLabels=item.infoLabels, url=destino)
         
         library.save_library_movie(library_item)
         
-      elif item.contentType == "episode":
+      elif item.contentType == "episode" and item.infoLabels["tmdb_id"]:
         library_item = Item(title="Descargado: %s" % item.downloadFilename, channel= "descargas", action="findvideos", infoLabels=item.infoLabels, url=destino)
         
         tvshow = Item(channel= "descargas", contentType="tvshow", infoLabels = {"tmdb_id": item.infoLabels["tmdb_id"]})
@@ -645,11 +645,12 @@ def get_episodes(item):
             episode.contentEpisodeNumber = season_and_episode.split("x")[1]
           
         #Buscamos en tmdb
-        tmdb.find_and_set_infoLabels_tmdb(episode)
+        if item.infoLabels["tmdb_id"]:
+          tmdb.find_and_set_infoLabels_tmdb(episode)
                 
         #Episodio, Temporada y Titulo
         if not episode.contentTitle:
-          episode.contentTitle = episode.title
+          episode.contentTitle = re.sub("\[[^\]]+\]|\([^\)]+\)|\d*x\d*\s*-","",episode.title).strip()
           
         episode.downloadFilename = os.path.join(item.downloadFilename,"%dx%0.2d - %s" % (episode.contentSeason, episode.contentEpisodeNumber, episode.contentTitle.strip()))
         

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -229,7 +229,10 @@ def run():
 
             # Special action for downloading all episodes from a serie
             elif item.action == "download_all_episodes":
-                downloadtools.download_all_episodes(item, channel)
+                from channels import descargas
+                item.action = item.extra
+                del item.extra
+                descargas.save_download(item)
 
             # Special action for searching, first asks for the words then call the "search" function
             elif item.action == "search":


### PR DESCRIPTION
Corregido:
- Opción 'Descargar todos los episodios' probado en HDFull
- Si le das a Cancelar al buscar serie, no vuelve a preguntar en cada episodio
- Descarga la serie sin estar identificada (pero no la pasa a la biblioteca)
- Eliminadas etiquetas de color en el titulo cuando contentTitle no esta disponible


Prueba a ver si ya no te da error