### PR TITLE
fix controles en mediaserver

### DIFF
--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -537,7 +537,9 @@ def get_server_controls_settings(server_name):
     dict_settings = {}
 
     list_controls = get_server_parameters(server_name).get('settings',[])
-
+    import copy
+    list_controls = copy.deepcopy(list_controls)
+    
     # Conversion de str a bool, etc...
     for c in list_controls:
         if 'id' not in c or 'type' not in c or 'default' not in c:


### PR DESCRIPTION
Buenas, He corregido los controles de ajustes de servidores en mediaserver, que al abrirles por segunda vez daban fallo al quitar el copy, lo he puesto en get_server_controls_settings para que no afecte al rendimiento
